### PR TITLE
Fix notification retry propagation

### DIFF
--- a/src/Notifications/Notifications.Service/OrderNotificationConsumer.cs
+++ b/src/Notifications/Notifications.Service/OrderNotificationConsumer.cs
@@ -142,7 +142,9 @@ IConsumer<OrderStatusUpdatedEvent>
         catch (Exception exception)
         {
             NotificationMetrics.RecordFailure("email", exception is HttpRequestException ? "provider" : "unexpected");
-            _logger.LogWarning(exception, "[Notification] Email send failed for template {Template}, order {OrderId}. Notification was persisted but email delivery failed.", template, orderId);
+            NotificationMetrics.RecordConsumerRetry(nameof(OrderNotificationConsumer), "email");
+            _logger.LogWarning(exception, "[Notification] Email send failed for template {Template}, order {OrderId}. Notification was persisted and email delivery will be retried.", template, orderId);
+            throw;
         }
     }
 }


### PR DESCRIPTION
The notification CI test fails because email provider exceptions are logged and suppressed, so MassTransit cannot retry transient delivery failures.

This change records the retry metric, updates the failure log to reflect retry behavior, and rethrows the provider exception so the configured broker retry policy can handle it.